### PR TITLE
docs: Update command to install Laravel Web Tinker to use --dev flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple Chrome extension to iframe a PHP console. This package utilizes [Spatie
 2. Navigate to `chrome://extensions/` in your browser.
 3. Enable "Developer mode" in the top right corner (if not already enabled).
 4. Click "Load unpacked" and select the `php-ext` folder.
-5. Within any Laravel project, install the Spatie Laravel Web Tinker package: `composer require spatie/laravel-web-tinker`
+5. Within any Laravel project, install the Spatie Laravel Web Tinker package: `composer require spatie/laravel-web-tinker --dev`
 
 ## Run Tinker in DevTools
 


### PR DESCRIPTION
Since the [Laravel Web Tinker README](https://github.com/spatie/laravel-web-tinker?tab=readme-ov-file#-a-word-to-the-wise-) mentions that we should never install or use this in a production environment, I figure it might be good to update the README of this extension to use the  `--dev` flag so it is added as a dev dependency instead.

Hope this helps.